### PR TITLE
Fix panEnabled and zoomEnabled swapped in constructor

### DIFF
--- a/src/PanZ.js
+++ b/src/PanZ.js
@@ -64,8 +64,8 @@ export default class PanZ extends Base {
 
     this.bounds = bounds;
     this.boundingElement = boundingElement;
-    this._zoomEnabled = panEnabled;
-    this._panEnabled = zoomEnabled;
+    this._zoomEnabled = zoomEnabled;
+    this._panEnabled = panEnabled;
     this._zoomSpeed = zoomSpeed / 100;
     this.minZoom = minZoom;
     this.maxZoom = maxZoom;


### PR DESCRIPTION
When supplying options in the constructor, panEnabled and zoomEnabled have the opposite effect than expected. This is due to a typo where the two variables are swapped.